### PR TITLE
Add commands to reboot the server, Nginx, MySQL, and Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ To push this file to Forge again, call `forge nginx:push`.
 Once you have made changes to your `forge.yml` file, use the `forge config:push`
 command to synchronize your local settings to Forge.
 
+## Rebooting the server or services
+
+You can reboot the server or services by using the following commands:
+
+* `forge reboot:server` - reboot the server
+* `forge reboot:nginx` - reboot Nginx
+* `forge reboot:mysql` - reboot MySQL
+* `forge reboot:postgres` - reboot Postgres
+
+Every `reboot` command requires confirmation, which you can provide by adding the `--confirm` option.
+
+**IMPORTANT:** Please remember that rebooting the server or services may cause temporary downtime!
+Running the command will only _initiate_ the reboot process. It is up to you to perform whatever steps
+are necessary to confirm that the server or service has properly rebooted.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/app/Commands/RebootCommand.php
+++ b/app/Commands/RebootCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Commands;
+
+use App\Support\Configuration;
+use Laravel\Forge\Forge;
+
+abstract class RebootCommand extends ForgeCommand
+{
+    /** @var Forge */
+    protected $forge;
+
+    /** @var Configuration */
+    protected $configuration;
+
+    /** @var string the name of what is being rebooted */
+    protected $subject = '';
+
+    public function handle(Forge $forge, Configuration $configuration)
+    {
+        if (! $this->ensureHasToken()) {
+            return 1;
+        }
+
+        if (! $this->ensureHasForgeConfiguration()) {
+            return 1;
+        }
+
+        $this->forge = $forge;
+        $this->configuration = $configuration;
+
+        if (! $this->option('confirm')) {
+            $this->warn('Rebooting ' . $this->subject . ' requires confirmation');
+            $this->warn('Please use --confirm to confirm that you want to reboot ' . $this->subject);
+
+            return 1;
+        }
+
+        $this->info('Rebooting ' . $this->subject);
+
+        $this->reboot();
+
+        $this->info('Depending on the server, this may take some time and may cause temporary downtime');
+    }
+
+    abstract public function reboot();
+}

--- a/app/Commands/RebootMySQLCommand.php
+++ b/app/Commands/RebootMySQLCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Commands;
+
+class RebootMySQLCommand extends RebootCommand
+{
+    protected $signature = 'reboot:mysql {--confirm}';
+
+    protected $description = 'Reboot MySQL';
+
+    protected $subject = 'MySQL';
+
+    public function reboot()
+    {
+        $serverId = $this->configuration->get('server');
+
+        $this->forge->rebootMysql($serverId);
+    }
+}

--- a/app/Commands/RebootNginxCommand.php
+++ b/app/Commands/RebootNginxCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Commands;
+
+class RebootNginxCommand extends RebootCommand
+{
+    protected $signature = 'reboot:nginx {--confirm}';
+
+    protected $description = 'Reboot Nginx';
+
+    protected $subject = 'Nginx';
+
+    public function reboot()
+    {
+        $serverId = $this->configuration->get('server');
+
+        $this->forge->rebootNginx($serverId);
+    }
+}

--- a/app/Commands/RebootPostgresCommand.php
+++ b/app/Commands/RebootPostgresCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Commands;
+
+class RebootPostgresCommand extends RebootCommand
+{
+    protected $signature = 'reboot:postgres {--confirm}';
+
+    protected $description = 'Reboot Postgres';
+
+    protected $subject = 'Postgres';
+
+    public function reboot()
+    {
+        $serverId = $this->configuration->get('server');
+
+        $this->forge->rebootPostgres($serverId);
+    }
+}

--- a/app/Commands/RebootServerCommand.php
+++ b/app/Commands/RebootServerCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Commands;
+
+class RebootServerCommand extends RebootCommand
+{
+    protected $signature = 'reboot:server {--confirm}';
+
+    protected $description = 'Reboot the server';
+
+    protected $subject = 'the server';
+
+    public function reboot()
+    {
+        $serverId = $this->configuration->get('server');
+
+        $this->forge->rebootServer($serverId);
+    }
+}


### PR DESCRIPTION
Added the following commands:

* `reboot:server`
* `reboot:nginx`
* `reboot:mysql`
* `reboot:postgres`

Given the nature of what these commands do, they require the `--confirm` option.

I added a base `RebootCommand` so that it's easy to build out more reboot commands as they are added to the SDK (e.g. redis and supervisor are in the Forge UI but not the API yet)