### PR TITLE
Silence error if quick deploy is already enabled

### DIFF
--- a/app/Sync/DeploymentScriptSync.php
+++ b/app/Sync/DeploymentScriptSync.php
@@ -17,7 +17,7 @@ class DeploymentScriptSync extends BaseSync
         $deploymentScriptOnForge = $this->forge->siteDeploymentScript($server->id, $site->id);
 
         if (!$force && $deploymentScript !== $deploymentScriptOnForge) {
-            $output->warning("Skipping the deployment log update, as the script on Forge is different than your local script.\nUse --force to overwrite it.");
+            $output->warning("Skipping the deployment script update, as the script on Forge is different than your local script.\nUse --force to overwrite it.");
             return;
         }
 

--- a/app/Sync/DeploymentScriptSync.php
+++ b/app/Sync/DeploymentScriptSync.php
@@ -3,6 +3,7 @@
 namespace App\Sync;
 
 use Illuminate\Console\OutputStyle;
+use Laravel\Forge\Exceptions\ValidationException;
 use Laravel\Forge\Resources\Server;
 use Laravel\Forge\Resources\Site;
 use Laravel\Forge\Resources\Webhook;
@@ -23,7 +24,13 @@ class DeploymentScriptSync extends BaseSync
         $this->forge->updateSiteDeploymentScript($server->id, $site->id, $deploymentScript);
 
         if ($this->config->get($environment, 'quick-deploy')) {
-            $site->enableQuickDeploy();
+            try {
+                $site->enableQuickDeploy();
+            } catch (ValidationException $e) {
+                if (! in_array('Hook already exists on this repository', $e->errors())) {
+                    throw $e;
+                }
+            }
         } else {
             $site->disableQuickDeploy();
         }


### PR DESCRIPTION
This PR catches and silences an error returned by the Forge SDK after calling `forge config:push` if a quick deploy webhook already exists for the site.

Yesterday this threw a `FailedActionException` because the error actually comes from GitHub, I emailed the Forge team about it and they're going to handle the error themselves. It looks like they may have already begun working on this since it now throws a `ValidationException`. @jbrooksuk if you have a minute, do you know if this might change again? If it will, this PR should probably wait until that's finalized.

Unrelated: fixed the wording of the deployment script warning message.