### PR TITLE
Dump deployment script as multi-line block

### DIFF
--- a/app/Support/Configuration.php
+++ b/app/Support/Configuration.php
@@ -43,7 +43,9 @@ class Configuration
 
     public function store(string $configFile)
     {
-        $configContent = Yaml::dump($this->config, 4, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $flags = Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK;
+
+        $configContent = Yaml::dump($this->config, 4, 2, $flags);
 
         file_put_contents($configFile, $configContent);
     }
@@ -67,7 +69,7 @@ class Configuration
             'name' => $site->name,
             'server' => $server->id,
             'quick-deploy' => $site->quickDeploy,
-            'deployment' => explode("\n", $site->getDeploymentScript()),
+            'deployment' => $site->getDeploymentScript(),
             'webhooks' => $this->getWebhooks($server, $site),
             'daemons' => $this->getDaemons($server, $site),
         ];

--- a/app/Sync/DeploymentScriptSync.php
+++ b/app/Sync/DeploymentScriptSync.php
@@ -13,7 +13,7 @@ class DeploymentScriptSync extends BaseSync
 
     public function sync(string $environment, Server $server, Site $site, OutputStyle $output, bool $force = false): void
     {
-        $deploymentScript = join("\n", $this->config->get($environment, 'deployment', ''));
+        $deploymentScript = is_array($script = $this->config->get($environment, 'deployment', '')) ? join("\n", $script) : $script;
         $deploymentScriptOnForge = $this->forge->siteDeploymentScript($server->id, $site->id);
 
         if (!$force && $deploymentScript !== $deploymentScriptOnForge) {


### PR DESCRIPTION
Adds `Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK` so the deployment script is dumped as a multi-line string instead of an array of strings representing each line.

Removes the visual noise of `- ''` for blank lines, handles quotes a bit more nicely (doesn't need to escape them), and technically makes it so that the deploy script appears **exactly** as it does in Forge, including all formatting. Also, in my opinion at least, looks better.

I added a check for an array when retrieving existing configs, so this should be completely backwards-compatible.

Before:

```yaml
deployment:
  - 'cd /home/forge/site.com'
  - ''
  - 'git pull origin master'
  - ''
  - 'composer install --no-interaction --no-dev --prefer-dist --optimize-autoloader'
  - ''
  - 'npm ci && npm run prod'
  - ''
  - '( flock -w 10 9 || exit 1'
  - '    echo ''Restarting FPM...''; sudo -S service php7.4-fpm reload ) 9>/tmp/fpmlock'
  - ''
  - '$FORGE_PHP artisan queue:restart'
```

After:

```yaml
deployment: |
  cd /home/forge/site.com

  git pull origin master

  composer install --no-interaction --no-dev --prefer-dist --optimize-autoloader

  npm ci && npm run prod

  ( flock -w 10 9 || exit 1
      echo 'Restarting FPM...'; sudo -S service php7.4-fpm reload ) 9>/tmp/fpmlock

  $FORGE_PHP artisan queue:restart
```