### PR TITLE
Add support for Forge workers

### DIFF
--- a/app/Commands/PushConfigCommand.php
+++ b/app/Commands/PushConfigCommand.php
@@ -7,6 +7,7 @@ use App\Sync\BaseSync;
 use App\Sync\DaemonSync;
 use App\Sync\DeploymentScriptSync;
 use App\Sync\WebhookSync;
+use App\Sync\WorkerSync;
 use Illuminate\Console\Scheduling\Schedule;
 use Laravel\Forge\Forge;
 use Laravel\Forge\Resources\Server;

--- a/app/Commands/PushConfigCommand.php
+++ b/app/Commands/PushConfigCommand.php
@@ -20,6 +20,7 @@ class PushConfigCommand extends ForgeCommand
         WebhookSync::class,
         DeploymentScriptSync::class,
         DaemonSync::class,
+        WorkerSync::class,
     ];
 
     protected $signature = 'config:push {environment=production} {--force}';

--- a/app/Support/Defaults.php
+++ b/app/Support/Defaults.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support;
+
+class Defaults
+{
+    public static function worker(string $php): array
+    {
+        return [
+            'queue' => 'default', // Note: defaults to blank if omitted
+            'connection' => 'redis', // Required by Forge API
+            'php_version' => $php, // Required by Forge API
+            'daemon' => false, // Required by Forge API
+            'processes' => 1,
+            'timeout' => 60, // Note: defaults to 0 (no timeout) if omitted
+            'sleep' => 10, // Required by Forge API
+            'delay' => 0,
+            'tries' => null,
+            'environment' => null,
+            'force' => false,
+        ];
+    }
+}

--- a/app/Sync/WorkerSync.php
+++ b/app/Sync/WorkerSync.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Sync;
+
+use App\Support\Defaults;
+use Illuminate\Console\OutputStyle;
+use Laravel\Forge\Resources\Server;
+use Laravel\Forge\Resources\Site;
+use Laravel\Forge\Resources\Worker;
+
+class WorkerSync extends BaseSync
+{
+    public function sync(string $environment, Server $server, Site $site, OutputStyle $output, bool $force = false): void
+    {
+        $workers = collect($this->config->get($environment, 'workers', []));
+        $forgeWorkers = collect($this->forge->workers($server->id, $site->id))->keyBy('id');
+
+        // Create workers that are defined locally but do not exist on Forge
+        $workers->reject(function (array $worker) use (&$forgeWorkers, $server, $site) {
+            if ($match = $forgeWorkers->first(fn (Worker $forge) => $this->equivalent($server, $forge, $worker))) {
+                // Remove each found worker from the list of 'unmatched' workers on Forge
+                $forgeWorkers->forget($match->id);
+
+                return true;
+            }
+        })->map(function (array $worker) use ($server, $site, $output) {
+            $data = $this->getWorkerPayload($server, $worker);
+
+            $output->writeln("Creating {$data['queue']} queue worker on {$data['connection']} connection...");
+
+            $this->forge->createWorker($server->id, $site->id, $data);
+        });
+
+        if ($forgeWorkers->isNotEmpty()) {
+            if ($force) {
+                $forgeWorkers->map(function (Worker $worker) use ($server, $site, $output) {
+                    $output->writeln("Deleting {$worker->queue} queue worker present on Forge but not listed locally...");
+
+                    $this->forge->deleteWorker($server->id, $site->id, $worker->id);
+                });
+            } else {
+                $output->writeln("Found {$forgeWorkers->count()} queue workers present on Forge but not listed locally.");
+                $output->writeln('Run the command again with the `--force` option to delete them.');
+            }
+        }
+    }
+
+    protected function equivalent(Server $server, Worker $worker, array $config): bool
+    {
+        $cli = collect($this->forge->phpVersions($server->id))->firstWhere('usedOnCli', true)->version;
+
+        $defaults = Defaults::worker($cli);
+
+        $forgeWorker = [
+            'queue' => $worker->queue,
+            'connection' => $worker->connection,
+            'timeout' => $worker->timeout,
+            'delay' => $worker->delay,
+            'sleep' => $worker->sleep,
+            'tries' => $worker->tries,
+            'environment' => $worker->environment,
+            'daemon' => (bool) $worker->daemon,
+            'force' => (bool) $worker->force,
+            'php_version' => str_replace('.', '', head(explode(' ', $worker->command))),
+            'processes' => $worker->processes,
+        ];
+
+        foreach (array_merge($defaults, $config) as $key => $value) {
+            if ($forgeWorker[$key] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function getWorkerPayload(Server $server, array $worker): array
+    {
+        $cli = collect($this->forge->phpVersions($server->id))->firstWhere('usedOnCli', true)->version;
+
+        return array_merge(Defaults::worker($cli), $worker);
+    }
+}


### PR DESCRIPTION
This PR adds support for syncing Forge workers 🤖 

**Pulling down workers from Forge**

I added a new `workers` config key to store workers. The `config:pull` command can now retrieve a list of workers and store them in the config file under this key.

Values that are determined to be identical to the 'defaults' (see below) are not written to the config file, with two exceptions—the `queue` and `connection` variables are always written, even when they are the defaults (`default` and `redis`). This was just my opinion about what the bare minimum config values should be in order for the config file to make sense to look at, they aren't technically necessary and we could easily store more than that. Non-default values will always be written to the config file.

Example:

```yaml
  workers:
    -
      queue: default
      connection: redis
      daemon: true
    -
      queue: emails
      connection: redis
      sleep: 30
      tries: 3
```

**Pushing workers up to Forge**

I added a new `WorkerSync` class that runs as part of the `config:push` command. It behaves similarly to the other sync classes, diffing the resources found locally and on Forge and then creating/deleting Forge resources as necessary.

Like the `config:pull` command, `WorkerSync` knows what the 'default' configuration values are for queue workers and will avoid creating/deleting workers with missing configuration values if those values are the defaults. For example, a locally configured worker with no `timeout` key will be considered identical to a worker found on Forge with a `timeout` value of `60`, since `60` is the default. See below and the related testing PR (#21) for more details about how this works.

Like the other sync classes, `WorkerSync` won't actually delete Forge resources unless the `--force` flag is passed.

**`Defaults`**

To avoid storing lots of huge arrays of mostly-redundant properties, this PR also adds the concept of 'default' properties for Forge resources.

In this case I added a 'default worker' containing the default values for the worker configuration options available in the Forge UI. These defaults are not perfect—it doesn't appear to be possible to get or set the 'Maximum memory' and 'Directory' options through the Forge API at all, so I left these out, and the PHP version is returned in a format that isn't great for storing in the Yaml config file. Additionally, some of the UI and API defaults are different—leaving the `timeout` blank, for example, will default to 60 seconds in the Forge UI but 0 (no timeout) using the API. I tried to choose behaviour that would be intuitive and as similar to the Forge **UI** as possible.

My other goal with this class is to prevent having to repeat these default values in multiple places. Including the code in my related testing PR, these values are needed in 4 or 5 places, so I wanted to keep them in one place so they don't drift and become inconsistent.